### PR TITLE
Added non-normative sections to specification as introduction

### DIFF
--- a/src/stomp-specification-1.1.md
+++ b/src/stomp-specification-1.1.md
@@ -23,6 +23,10 @@ draft document.
 
 ### Background
 
+STOMP was originally designed as ...
+
+[To be completed by someone who was there !!!]
+
 ### Protocol Overview
 
 STOMP is a frame based protocol, with frames modelled on HTTP. A frame


### PR DESCRIPTION
Hiram, Brian,

I've fleshed out the spec to have more of an introduction, and mention explicitly the implementation specific parts.

Can you merge this into the main spec.   Also there's a `Background` paragraph in the introduction which needs some text on the original justification for STOMP.  I know Brian sent something to the list at some point, but I can't see to find the text - could one of the 1.0 authors put something in there to round out the document.

cheers,

James.
