### PR TITLE
Gender error content length

### DIFF
--- a/src/stomp-specification-1.1.md
+++ b/src/stomp-specification-1.1.md
@@ -515,7 +515,7 @@ abort\!
 
 ### DISCONNECT
 
-A client can disconnect from the server at anytime by closing his socket but
+A client can disconnect from the server at anytime by closing the socket but
 there is no guarantee that the previously sent frames have been received by
 the server. To do a graceful shutdown, where the client is assured that all
 previous frames have been received by the server, the client SHOULD:
@@ -644,6 +644,7 @@ the body MAY contain more detailed information (or MAY be empty).
     ERROR
     receipt-id:message-12345
     content-type:text/plain
+    content-length:171
     message: malformed frame received
 
     The message:


### PR DESCRIPTION
Changes suggested by gmallard in the stomp-spec Google group:

The last sentence in the ERROR section says: 
ERROR frames SHOULD include a content-length head and a content-type 
header if a body is present. 
Two points: 
a) Suggest changing that verbiage to: 
ERROR frames SHOULD include a content-length header and a content-type 
header if a body is present. 
b) Suggest actually including a content-length header in the previous 
example, which does contain a body. 
content-length:171 
(Check that length please...) 
Regards, G.
