### PR TITLE
Gender error content length

### DIFF
--- a/src/stomp-specification-1.1.md
+++ b/src/stomp-specification-1.1.md
@@ -668,7 +668,7 @@ frame SHOULD set the `receipt-id` header to match the value of the `receipt`
 header of the frame which the error is related to.
 
 `ERROR` frames SHOULD include a
-[`content-length`](#Header_content-length) head and a
+[`content-length`](#Header_content-length) header and a
 [`content-type`](#Header_content-type) header if a body is present.
 
 ## Heart-beating


### PR DESCRIPTION
Changes suggested by gmallard on the stomp-spec google group:

The last sentence in the ERROR section says: 
ERROR frames SHOULD include a content-length head and a content-type 
header if a body is present. 
Two points: 
a) Suggest changing that verbiage to: 
ERROR frames SHOULD include a content-length header and a content-type 
header if a body is present. 
b) Suggest actually including a content-length header in the previous 
example, which does contain a body. 
content-length:171 
(Check that length please...) 
Regards, G. 
