### PR TITLE
adding OnStomp to implementations

### DIFF
--- a/src/implementations.page
+++ b/src/implementations.page
@@ -154,4 +154,6 @@ table.clients
       * [activemessaging](http://code.google.com/p/activemessaging/) s an attempt
         to bring the simplicity and elegance of Rails development to the world of
         messaging
+      * [onstomp gem](https://rubygems.org/gems/onstomp) it's source is at
+        https://github.com/meadvillerb/onstomp
 


### PR DESCRIPTION
Added onstomp ruby gem to the list of implementations.  It also supports STOMP 1.1, but I didn't want to make any drastic changes to the implementations page by adding a whole new section.
