### PR TITLE
remove cruft from hxstomp URL which was causing a 404

### DIFF
--- a/src/implementations.page
+++ b/src/implementations.page
@@ -155,7 +155,7 @@ table.clients
 
   - language("haXe")
     :markdown
-      * [hxStomp](hxstomp|http://code.google.com/p/hxstomp/) is a TCP socket-based
+      * [hxStomp](http://code.google.com/p/hxstomp/) is a TCP socket-based
         Stomp protocol client library written for the [Haxe](http://www.haxe.org)
         language.
 


### PR DESCRIPTION
On the "implementations" page, clicking on the link for hxstomp resulted in visiting the page http://stomp.github.com/hxstomp%7Chttp://code.google.com/p/hxstomp/ which of course does not exist.

So, I removed the extraneous "hxstomp|" at the beginning of the URL.
