### PR TITLE
Update src/stomp-specification-1.2.md

### DIFF
--- a/src/stomp-specification-1.2.md
+++ b/src/stomp-specification-1.2.md
@@ -828,7 +828,7 @@ defined in this specification that each frame MUST or MAY use:
     * OPTIONAL: none
 * `DISCONNECT`
     * REQUIRED: none
-    * OPTIONAL: none
+    * OPTIONAL: receipt
 * `MESSAGE`
     * REQUIRED: `destination`, `message-id`, `subscription`
     * OPTIONAL: `ack`


### PR DESCRIPTION
DISCONNECT may have an optional header `receipt`.
