### PR TITLE
add RabbitMQ to 1.1 and 1.2 server list

### DIFF
--- a/src/implementations.page
+++ b/src/implementations.page
@@ -33,6 +33,9 @@ The Simple Text Oriented Messaging Protocol
   * [Apache Apollo](http://activemq.apache.org/apollo) a redesigned version of 
     ActiveMQ.
 
+  * [RabbitMQ](http://www.rabbitmq.com/plugins.html#rabbitmq-stomp) an Erlang-based,
+    multi-protocol broker with full support for STOMP via a plugin.
+
   # STOMP 1.1 Servers
 
   The following is a list of the various STOMP 1.1 compliant message 
@@ -40,6 +43,9 @@ The Simple Text Oriented Messaging Protocol
 
   * [Apache Apollo](http://activemq.apache.org/apollo) a redesigned version of 
     ActiveMQ.
+
+  * [RabbitMQ](http://www.rabbitmq.com/plugins.html#rabbitmq-stomp) an Erlang-based,
+    multi-protocol broker with full support for STOMP via a plugin.
 
   # STOMP 1.1 Clients
   Pick the right Stomp client for your particular language or platform.


### PR DESCRIPTION
The RabbitMQ server has been supporting STOMP 1.1 for a while - since version 2.3.0, and more recently, in 3.0.0, added support for STOMP 1.2.

Also fixed a minor typo.
