### PR TITLE
added stompest to STOMP 1.2 clients (layout fix)

### DIFF
--- a/src/implementations.page
+++ b/src/implementations.page
@@ -49,6 +49,7 @@ table.clients
     :markdown
       * [stompest](https://github.com/nikipore/stompest)
 
+:markdown
   # STOMP 1.1 Servers
 
   The following is a list of the various STOMP 1.1 compliant message 


### PR DESCRIPTION
The layout of the STOMP 1.2 clients table is broken. Lacking a layout preview, I'm just guessing whether that fixed it.
